### PR TITLE
Remove duplicated API and add qml example for current login user

### DIFF
--- a/examples/qml/current-login-user.qml
+++ b/examples/qml/current-login-user.qml
@@ -1,0 +1,34 @@
+
+
+import QtQuick 2.2
+import QtQuick.Window 2.1
+import QtAccountsService 1.0
+
+Window {
+    width: 300; height: 200
+    title: "AccountsService Qt binding"
+
+    UserAccount {
+        id: userAccount
+        Component.onCompleted: {
+            faceIcon.source = iconFileName;
+            loginName.text = userName;
+            displayName.text = userAccount.displayName;
+        }
+    }
+
+    Image {
+        id: faceIcon
+    }
+
+    Text {
+        id: loginName
+        anchors.left: faceIcon.right
+    }
+
+    Text {
+        id: displayName
+        anchors.top: loginName.bottom
+        anchors.left: loginName.left
+    }
+}

--- a/examples/qml/current-login-user.qml
+++ b/examples/qml/current-login-user.qml
@@ -1,4 +1,28 @@
-
+/****************************************************************************
+ * This file is part of Qt AccountsService Addon.
+ *
+ * Copyright (C) 2015 Leslie Zhai <xiang.zhai@i-soft.com.cn>
+ *
+ * Author(s):
+ *    Leslie Zhai
+ *
+ * $BEGIN_LICENSE:LGPL2.1+$
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * $END_LICENSE$
+ ***************************************************************************/
 
 import QtQuick 2.2
 import QtQuick.Window 2.1

--- a/src/accountsservice/accountsmanager.cpp
+++ b/src/accountsservice/accountsmanager.cpp
@@ -221,30 +221,6 @@ UserAccount *AccountsManager::findUserByName(const QString &userName)
     return new UserAccount(path.path());
 }
 
-void AccountsManager::slotUserAccountChanged() 
-{
-    emit userAccountChanged();
-}
-
-/*!
-    Find user iconFileName
-    
-    \param userName The name of the user you want to find
-    \return the iconFile path
- */
-QString AccountsManager::findUserIconFile(const QString &userName) 
-{
-    UserAccount *user = findUserByName(userName);
-    
-    if (user) {
-        connect(user, SIGNAL(accountChanged()), 
-                this, SLOT(slotUserAccountChanged()));
-        return user->iconFileName();
-    }
-
-    return QString();
-}
-
 /*!
     Creates a new \a accountType type user account whose name is \a userName,
     real name is \a fullName.

--- a/src/accountsservice/accountsmanager.h
+++ b/src/accountsservice/accountsmanager.h
@@ -53,8 +53,6 @@ public:
     UserAccount *findUserById(uid_t uid);
     UserAccount *findUserByName(const QString &userName);
 
-    Q_INVOKABLE QString findUserIconFile(const QString &userName);
-
     bool createUser(const QString &userName,
                     const QString &fullName,
                     UserAccount::AccountType accountType);
@@ -65,13 +63,9 @@ public:
 Q_SIGNALS:
     void userAdded(UserAccount *);
     void userDeleted(UserAccount *);
-    void userAccountChanged();
 
 protected:
     AccountsManagerPrivate *d_ptr;
-
-private slots:
-    void slotUserAccountChanged();
 
 private:
     Q_DECLARE_PRIVATE(AccountsManager)

--- a/src/imports/accountsservice/plugins.qmltypes
+++ b/src/imports/accountsservice/plugins.qmltypes
@@ -21,12 +21,6 @@ Module {
             name: "userDeleted"
             Parameter { type: "UserAccount"; isPointer: true }
         }
-        Signal { name: "userAccountChanged" }
-        Method {
-            name: "findUserIconFile"
-            type: "string"
-            Parameter { name: "userName"; type: "string" }
-        }
     }
     Component {
         name: "QtAccountsService::UserAccount"


### PR DESCRIPTION
Hi @plfiorini 

It is my fault ;P UserAccount`s default constructor is able to get current login user, so findUserIconFile in AccountsManager is duplicate, also the same story about userAccountChanged signal.

Regards,
Leslie Zhai